### PR TITLE
Få databindningen att funka

### DIFF
--- a/checkbox.html
+++ b/checkbox.html
@@ -4,7 +4,7 @@
 
     <label ng-repeat="option in question.choices">
 
-        <md-checkbox ng-model="model">
+        <md-checkbox ng-model="model.value">
             {{option.option}}
         </md-checkbox>
 

--- a/form.controller.js
+++ b/form.controller.js
@@ -7,7 +7,9 @@ if (!academy.form) {
 
 academy.form.FormController = function () {
     var vm = this;
-    vm.data = [];
+    vm.data = [{
+        value: false
+    }];
     vm.submit = submit;
     vm.form = { "formtitle" :"test form",
         "questions" : [


### PR DESCRIPTION
Reproducerade även problemet [här](https://jsfiddle.net/n1ycqu6j/), med något mindre kod. (Och för att bevisa för mig själv att `md-checkbox` inte var inblandad.)

I korthet: någonting går fel för att vi binder mot primitiva värden (`true`/`false`) istället för referenser. När vi binder mot en referens så funkar det hela.

Därför skapade jag ett extra lager av objekt i arrayen `$scope.data`. Då funkar det.

Notera att nu när det funkar så ser man att alla tre checkboxarna binder till samma modell. Det är för att det är så det står i koden. Kanske inte vad ni avsåg, dock. Men nu borde det vara lättare att ändra, när det funkar.

Under tiden som jag listade ut detta var jag också inne och frågade på `#angularjs`-kanalen på IRC. Fick [det här](https://jsfiddle.net/n1ycqu6j/1/) som motförslag. Det stämmer överens med hur jag hade lagt upp datamodellen: genom att lägga `checked` inne i `option`-objekten. Något att fundera på, kanske.

Det är fortfarande en smula oklart varför det inte funkar så som det var skrivet från början. Kanske det vi blir bitna av är maximen ["Don't bind to primitives"](http://www.codelord.net/2014/05/10/understanding-angulars-magic-dont-bind-to-primitives/)... det känns inte helt klockrent som förklaring, eller närmare bestämt så hade jag inte tolkat det som att det är ett problem där vi gör det, i `model`.